### PR TITLE
Hide Delimiter for small screens

### DIFF
--- a/src/components/Delimiter.tsx
+++ b/src/components/Delimiter.tsx
@@ -9,7 +9,7 @@ import classnames, {
 
 const bottomSeparator = classnames(
   width('w-fit'),
-  display('flex'),
+  display('hidden', 'sm:flex'),
   alignItems('items-center'),
   justifyContent('justify-center')
 )


### PR DESCRIPTION
- hide delimiter for mobile