### PR TITLE
Fix Twitter widget height

### DIFF
--- a/src/components/TweetsList/index.tsx
+++ b/src/components/TweetsList/index.tsx
@@ -91,7 +91,6 @@ export default function () {
                 'transparent',
               ].join(' '),
               width: '100%',
-              height: '100%',
               hide_media: true,
               hide_thread: true,
             }}


### PR DESCRIPTION
- removed `height` from the widget because it doesn't work with percentages

<img width="641" alt="Снимок экрана 2022-09-06 в 18 16 04" src="https://user-images.githubusercontent.com/5114069/188672379-85bcd250-ba08-430f-965e-0f18162d6004.png">
