### PR TITLE
Fix twitter links

### DIFF
--- a/src/components/BlockchainList/TwitterLink.tsx
+++ b/src/components/BlockchainList/TwitterLink.tsx
@@ -1,5 +1,5 @@
 import { LinkText } from 'components/Text'
-import { Suspense } from 'preact/compat'
+import { Suspense, useMemo } from 'preact/compat'
 import { useSnapshot } from 'valtio'
 import Delimiter from 'components/Delimiter'
 import postIdsStatuses from 'stores/PostIdsStatuses'
@@ -29,9 +29,11 @@ function TwitterLinkSuspended({ blockchainId }: TwitterLinkProps) {
 }
 
 export default function ({ blockchainId }: TwitterLinkProps) {
+  const id = useMemo(() => blockchainId - 1, [blockchainId])
+
   return (
     <Suspense fallback={null}>
-      <TwitterLinkSuspended blockchainId={blockchainId} />
+      <TwitterLinkSuspended blockchainId={id} />
     </Suspense>
   )
 }

--- a/src/components/BlockchainList/TwitterLink.tsx
+++ b/src/components/BlockchainList/TwitterLink.tsx
@@ -1,18 +1,14 @@
 import { LinkText } from 'components/Text'
-import { Suspense, useMemo } from 'preact/compat'
+import { Suspense } from 'preact/compat'
 import { useSnapshot } from 'valtio'
 import Delimiter from 'components/Delimiter'
 import postIdsStatuses from 'stores/PostIdsStatuses'
 
-interface TwitterLinkProps {
-  blockchainId: number
-}
-
-function TwitterLinkSuspended({ blockchainId }: TwitterLinkProps) {
+function TwitterLinkSuspended({ statusIndex }: { statusIndex: number }) {
   const { currentStatuses } = useSnapshot(postIdsStatuses)
 
-  if (!currentStatuses[blockchainId]) return null
-  const { serviceId } = currentStatuses[blockchainId]
+  if (!currentStatuses[statusIndex]) return null
+  const { serviceId } = currentStatuses[statusIndex]
 
   return (
     <>
@@ -28,12 +24,10 @@ function TwitterLinkSuspended({ blockchainId }: TwitterLinkProps) {
   )
 }
 
-export default function ({ blockchainId }: TwitterLinkProps) {
-  const id = useMemo(() => blockchainId - 1, [blockchainId])
-
+export default function ({ blockchainId }: { blockchainId: number }) {
   return (
     <Suspense fallback={null}>
-      <TwitterLinkSuspended blockchainId={id} />
+      <TwitterLinkSuspended statusIndex={blockchainId - 1} />
     </Suspense>
   )
 }


### PR DESCRIPTION
- change index of current statuses equal to `blockchainId - 1` to show a propper link to Twitter

![image](https://user-images.githubusercontent.com/5114069/222751728-74cad97c-330e-4b18-8395-f46703f789ce.png)
